### PR TITLE
Improving the code

### DIFF
--- a/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml
+++ b/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml
@@ -2,16 +2,19 @@
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 	<StackPanel>
-		<StackPanel Orientation="Horizontal">
-			<StackPanel Orientation="Vertical">
-				<TextBlock>Disassembly Format</TextBlock>
-				<TextBlock>Show Unwind Info</TextBlock>
-			</StackPanel>
-			<StackPanel Orientation="Vertical">
-				<ComboBox ItemsSource="{Binding DisassemblyFormats}" SelectedItem="{Binding DisassemblyFormat}"/>
-				<CheckBox IsChecked="{Binding IsChecked}"></CheckBox>
-
-			</StackPanel>
-		</StackPanel>
+		<Grid ShowGridLines="False">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition></ColumnDefinition>
+				<ColumnDefinition></ColumnDefinition>
+			</Grid.ColumnDefinitions>
+			<Grid.RowDefinitions>
+				<RowDefinition></RowDefinition>
+				<RowDefinition></RowDefinition>
+			</Grid.RowDefinitions>
+			<TextBlock Grid.Row="0" Grid.Column="0">Disassembly Format</TextBlock>
+			<ComboBox  Grid.Row="0" Grid.Column="1" ItemsSource="{Binding DisassemblyFormats}" SelectedItem="{Binding DisassemblyFormat}"/>
+			<TextBlock Grid.Row="1" Grid.Column="0">Show Unwind Info</TextBlock>
+			<CheckBox  Grid.Row="1" Grid.Column="1" IsChecked="{Binding IsShowUnwindInfo}"></CheckBox>
+		</Grid>
 	</StackPanel>
 </UserControl>

--- a/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunOptionPage.xaml.cs
@@ -35,7 +35,7 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 		{
 			Options s = new Options();
 			s.DisassemblyFormat = ReadyToRunOptions.GetDisassemblyFormat(settings);
-			s.IsChecked = ReadyToRunOptions.GetIsChecked(settings);
+			s.IsShowUnwindInfo = ReadyToRunOptions.GetIsShowUnwindInfo(settings);
 
 			this.DataContext = s;
 		}
@@ -48,7 +48,7 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 		public void Save(XElement root)
 		{
 			Options s = (Options)this.DataContext;
-			ReadyToRunOptions.SetDisassemblyOptions(root, s.DisassemblyFormat, s.IsChecked);
+			ReadyToRunOptions.SetDisassemblyOptions(root, s.DisassemblyFormat, s.IsShowUnwindInfo);
 		}
 	}
 
@@ -60,14 +60,14 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 			}
 		}
 
-		private bool isChecked;
-		public bool IsChecked {
+		private bool isShowUnwindInfo;
+		public bool IsShowUnwindInfo {
 			get {
-				return isChecked;
+				return isShowUnwindInfo;
 			}
 			set {
-				isChecked = value;
-				OnPropertyChanged(nameof(IsChecked));
+				isShowUnwindInfo = value;
+				OnPropertyChanged(nameof(IsShowUnwindInfo));
 			}
 		}
 

--- a/ILSpy.ReadyToRun/ReadyToRunOptions.cs
+++ b/ILSpy.ReadyToRun/ReadyToRunOptions.cs
@@ -42,13 +42,13 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 			}
 		}
 
-		public static bool GetIsChecked(ILSpySettings settings)
+		public static bool GetIsShowUnwindInfo(ILSpySettings settings)
 		{
 			if (settings == null) {
 				settings = ILSpySettings.Load();
 			}
 			XElement e = settings[ns + "ReadyToRunOptions"];
-			XAttribute a = e.Attribute("IsChecked");
+			XAttribute a = e.Attribute("IsShowUnwindInfo");
 			if (a == null) {
 				return false;
 			} else {
@@ -56,11 +56,11 @@ namespace ICSharpCode.ILSpy.ReadyToRun
 			}
 		}
 
-		public static void SetDisassemblyOptions(XElement root, string disassemblyFormat, bool isChecked)
+		public static void SetDisassemblyOptions(XElement root, string disassemblyFormat, bool IsShowUnwindInfo)
 		{
 			XElement section = new XElement(ns + "ReadyToRunOptions");
 			section.SetAttributeValue("DisassemblyFormat", disassemblyFormat);
-			section.SetAttributeValue("IsChecked", isChecked);
+			section.SetAttributeValue("IsShowUnwindInfo", IsShowUnwindInfo);
 
 			XElement existingElement = root.Element(ns + "ReadyToRunOptions");
 			if (existingElement != null) {


### PR DESCRIPTION
I made a few changes to the PR, most of them are just cosmetic changes, but there are a couple of functional changes listed below:

- Checking if the bitness is 64 before we decode the unwind info as AMD64.
- Avoid `WriteCommentLine(output, unwindInfo.ToString());`, there is no need to do so.
- Align the UnwindOpcode one instruction earlier so that it is paired up with the instruction it is supposed to undo.
